### PR TITLE
add build_depend about livox_ros_driver

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -52,6 +52,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>camera_info_manager</build_depend>
   <build_depend>tf</build_depend>
+    <build_depend>livox_ros_driver</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
@@ -68,6 +69,7 @@
   <run_depend>cmake_modules</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>livox_ros_driver</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
add build_depend about livox_ros_driver, in order to fix compile errors